### PR TITLE
make c14n_strip_ws dependent on c14n-alg; set transform alg to c14n/n…

### DIFF
--- a/src/xmlsec/__init__.py
+++ b/src/xmlsec/__init__.py
@@ -38,11 +38,17 @@ class Config(object):
     """
     default_signature_alg = pyconfig.setting("xmlsec.default_signature_alg", constants.ALGORITHM_SIGNATURE_RSA_SHA1)
     default_digest_alg = pyconfig.setting("xmlsec.default_digest_alg", constants.ALGORITHM_DIGEST_SHA1)
-    default_c14n_alg = pyconfig.setting("xmlsec.default_c14n_alg", constants.TRANSFORM_C14N_INCLUSIVE)
+    default_c14n_alg = pyconfig.setting("xmlsec.default_c14n_alg", constants.TRANSFORM_C14N_EXCLUSIVE)
     debug_write_to_files = pyconfig.setting("xmlsec.config.debug_write_to_files", False)
     same_document_is_root = pyconfig.setting("xmlsec.same_document_is_root", False)
     id_attributes = pyconfig.setting("xmlsec.id_attributes", ['ID', 'id'])
-    c14n_strip_ws = pyconfig.setting("xmlsec.c14n_strip_ws", False)
+
+    if default_c14n_alg in (constants.TRANSFORM_C14N_EXCLUSIVE, constants.TRANSFORM_C14N_INCLUSIVE):
+        c14n_strip_ws = True
+    else:
+        c14n_strip_ws = False
+    # Override whitespace handling - may break signature
+    #c14n_strip_ws = pyconfig.setting("xmlsec.c14n_strip_ws", False)
 
 
 config = Config()
@@ -362,7 +368,7 @@ def add_enveloped_signature(t,
                             pos=0):
     if transforms is None:
         transforms = (constants.TRANSFORM_ENVELOPED_SIGNATURE,
-                      constants.TRANSFORM_C14N_EXCLUSIVE_WITH_COMMENTS)
+                      constants.TRANSFORM_C14N_EXCLUSIVE)
 
     tmpl = _enveloped_signature_template(c14n_method, digest_alg, transforms, reference_uri, signature_alg)
     if pos == -1:


### PR DESCRIPTION
As pointed out by kislyuk in https://github.com/kislyuk/signxml/issues/41#issuecomment-231759210 the digest validation failure was due a mismatch between declared and actually used c14n algorithms.

I changed both c14n and transform algorithms to exclusive/no-comment. Signature verification with kislyuk lib is OK, and Shib IDP and SP consume the signed aggregate without choking.

But please review carefully, as I have no sound understanding of xmldsig processing.