### PR TITLE
sign: remove raw_sign argument again

### DIFF
--- a/src/xmlsec/crypto.py
+++ b/src/xmlsec/crypto.py
@@ -166,14 +166,11 @@ class XMLSecCryptoREST(XMlSecCrypto):
         super(XMLSecCryptoREST, self).__init__(source="rest", do_padding=False, private=True)
         self._keyspec = keyspec
 
-    def sign(self, data, raw_sign=False):
+    def sign(self, data):
         try:
             import requests
             import json
-            if raw_sign:
-                url = '{!s}/rawsign'.format(self._keyspec)
-            else:
-                url = '{!s}/sign'.format(self._keyspec)
+            url = '{!s}/rawsign'.format(self._keyspec)
             r = requests.post(url, json=dict(mech='RSAPKCS1', data=data.encode("base64")))
             if r.status_code != requests.codes.ok:
                 r.raise_for_status()


### PR DESCRIPTION
On second thought, XMLSecCryptoREST.sign() never uses a certificate
returned from the signer service, so it is safe (and faster!) to
always use the /rawsign endpoint.